### PR TITLE
Add ClientId to Organization structure

### DIFF
--- a/MicroEdge.Models.Organizations/src/MicroEdge.Models.Organizations/Organization.cs
+++ b/MicroEdge.Models.Organizations/src/MicroEdge.Models.Organizations/Organization.cs
@@ -18,6 +18,11 @@ namespace Microedge.Models.Organizations
         public string LegacyId { get; set; }
 
         /// <summary>
+        /// the Id of the client that this organization belongs to.
+        /// </summary>
+        public string ClientId { get; set; }
+
+        /// <summary>
         /// The organization name.
         /// </summary>
         public string Name { get; set; }


### PR DESCRIPTION
To mirror how we do grants updates, we'll need to fill in FunderId in the Organizations Worker, and to do that we need ClientId.